### PR TITLE
Harden orchestrator↔HASS against hung states + last-resort restart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,12 @@ gem "propshaft"
 gem "pg"
 gem "puma"
 
+# Last-resort backstop: reclaim a Puma thread (and its DB connection) if a
+# conversation turn wedges past the service timeout. Required as ...base so it does
+# NOT auto-insert with its 15s default — we insert it explicitly with our own
+# 120s service timeout in config/initializers/rack_timeout.rb.
+gem "rack-timeout", require: "rack/timeout/base"
+
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
 gem "solid_queue"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "puma"
 # Last-resort backstop: reclaim a Puma thread (and its DB connection) if a
 # conversation turn wedges past the service timeout. Required as ...base so it does
 # NOT auto-insert with its 15s default — we insert it explicitly with our own
-# 120s service timeout in config/initializers/rack_timeout.rb.
+# service timeout in config/initializers/rack_timeout.rb.
 gem "rack-timeout", require: "rack/timeout/base"
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-timeout (0.7.0)
     rackup (2.3.1)
       rack (>= 3)
     rails (8.1.3)
@@ -455,6 +456,7 @@ DEPENDENCIES
   pry-rails
   puma
   qualspec!
+  rack-timeout
   rails
   rspec-rails
   rubocop-rails-omakase

--- a/app/controllers/api/v1/home_assistant_webhook_controller.rb
+++ b/app/controllers/api/v1/home_assistant_webhook_controller.rb
@@ -8,6 +8,12 @@
 # fire-and-forget: enqueue a job or kick off async theater, then return so the
 # HTTP call doesn't block HASS.
 class Api::V1::HomeAssistantWebhookController < Api::V1::BaseController
+  # Minimum gap between two honored restart requests. Backed by SolidCache (DB), so
+  # the cooldown SURVIVES the restart it triggers — a box that comes back still
+  # unhealthy won't get thrashed into a boot loop; the next restart waits this long.
+  RESTART_COOLDOWN = 10.minutes
+  RESTART_CACHE_KEY = "backend_restart_requested_at"
+
   # POST /api/v1/hass/theme_song
   # Play a random theme song off the host speaker — e.g. an idle-attractor
   # automation drawing people over. Optional `max_seconds` caps playback.
@@ -47,5 +53,38 @@ class Api::V1::HomeAssistantWebhookController < Api::V1::BaseController
   def glitch_long
     ShowJob.perform_later("glitch_long")
     render_api_success(enqueued: true)
+  end
+
+  # POST /api/v1/hass/restart
+  # LAST-RESORT self-heal: gracefully restart the whole backend stack via the boot
+  # supervisor (bin/glitchcube-ctl restart → TERM the launchd job → KeepAlive
+  # respawns Puma + SolidQueue cleanly). Intended caller: a HASS watchdog automation
+  # that fires only after the backend has looked unhealthy for a long time (see
+  # automations/connectivity/backend_restart_watchdog.yaml).
+  #
+  # Reachable only while Puma still answers HTTP, so its real value is the "SolidQueue
+  # wedged / degraded but the web thread is alive" case — precisely when a fresh boot
+  # helps. If Rails is fully down the rest_command simply can't land (harmless).
+  #
+  # The script runs DETACHED in its own process group (so it survives Puma's own
+  # shutdown) after a short delay (so this 200 flushes to HASS first). The cooldown
+  # above prevents a restart loop if the box returns still-unhealthy.
+  def restart
+    if (last = Rails.cache.read(RESTART_CACHE_KEY))
+      Rails.logger.warn "🔁 Backend restart requested but within cooldown (last: #{last}) — ignoring"
+      return render_api_success(restarted: false, reason: "cooldown", last_restart: last)
+    end
+    Rails.cache.write(RESTART_CACHE_KEY, Time.current.iso8601, expires_in: RESTART_COOLDOWN)
+
+    trigger = params[:reason].to_s.presence || "unspecified"
+    Rails.logger.warn "🔁 Backend restart requested via HASS webhook (reason: #{trigger}) — spawning detached restart in 3s"
+
+    script = Shellwords.escape(Rails.root.join("bin/glitchcube-ctl").to_s)
+    logfile = Shellwords.escape(Rails.root.join("log/restart.log").to_s)
+    Process.detach(
+      Process.spawn("sleep 3 && #{script} restart >> #{logfile} 2>&1", pgroup: true)
+    )
+
+    render_api_success(restarted: true, reason: trigger)
   end
 end

--- a/app/services/conversation_orchestrator.rb
+++ b/app/services/conversation_orchestrator.rb
@@ -22,29 +22,25 @@ class ConversationOrchestrator
   end
 
   # The main entry point that executes the conversation flow step-by-step.
+  #
+  # Deliberately NOT wrapped in a DB transaction: the steps make a multi-minute
+  # brain-LLM call (and HASS reads), and holding an open transaction across those
+  # would pin a DB connection for the whole turn. There is no cross-row invariant
+  # that needs atomicity here — a partially-written turn (e.g. a Conversation with
+  # no ConversationLog) is tolerable and self-heals; we fail loudly instead.
   def call
     Rails.logger.info "🧠 Orchestration started for message: '#{@message}'"
 
-    # The entire flow is wrapped in a transaction to ensure data consistency
-    result = ActiveRecord::Base.transaction do
-      begin
-        run_setup
-        run_pre_llm_checks
-        run_llm_intention_call
-        run_action_execution
-        run_response_synthesis
-        run_finalization
-      rescue => e
-        # Catches exceptions from any step and formats a standard error response.
-        # Let the transaction rollback happen, then return error response
-        raise e
-      end
-    end
+    run_setup
+    run_pre_llm_checks
+    run_llm_intention_call
+    run_action_execution
+    run_response_synthesis
+    result = run_finalization
 
     Rails.logger.info "✅ Orchestration finished."
     result
   rescue => e
-    # Handle errors outside transaction to avoid rollback of error response
     log_and_handle_error(e)
   end
 

--- a/app/services/home_assistant_service.rb
+++ b/app/services/home_assistant_service.rb
@@ -178,7 +178,11 @@ class HomeAssistantService
   def make_request(request)
     uri = URI(request.uri)
 
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", read_timeout: timeout) do |http|
+    # open_timeout caps the TCP connect: a powered-off / black-holed HASS box would
+    # otherwise stall on Ruby's ~60s default connect before read_timeout applies,
+    # injecting dead-air into every turn (CubePersona.current_persona reads HASS on
+    # the sync request path). Net::OpenTimeout is rescued below → ConnectionError, fast.
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 5, read_timeout: timeout) do |http|
       response = http.request(request)
 
       case response.code.to_i

--- a/app/services/host_audio.rb
+++ b/app/services/host_audio.rb
@@ -11,6 +11,13 @@ module HostAudio
   SAY_VOICE = "Zarvox" # maximum robot
   SAY_TIMEOUT = 30
 
+  # Hard kill ceiling for an uncapped play (max_seconds: nil). ffplay -autoexit
+  # exits on its own at end-of-file, so this never truncates a real song — it only
+  # fires if the player WEDGES (audio-device contention is a known trouble spot),
+  # so a stuck ffplay can't pin a SolidQueue worker forever. No theme song or
+  # glitch bed runs anywhere near this long.
+  UNCAPPED_KILL_CEILING = 600
+
   # Fallback cap (percent) when quiet_mode is on but the HASS input_number is
   # missing/blank. Mirrors the input_number's own initial value.
   DEFAULT_QUIET_VOLUME = 50
@@ -37,7 +44,9 @@ module HostAudio
       parts << "-volume #{vol.round}" if vol
       parts << %(-af "afade=t=out:st=#{max_seconds - FADE_SECONDS}:d=#{FADE_SECONDS}") if max_seconds
       parts << Shellwords.escape(path.to_s)
-      run(parts.join(" "), timeout: max_seconds && max_seconds + 10)
+      # A cap tracks max_seconds; an uncapped play still gets a hard kill ceiling so
+      # a wedged ffplay is never joined on forever (host_audio.rb#run timeout: nil).
+      run(parts.join(" "), timeout: max_seconds ? max_seconds + 10 : UNCAPPED_KILL_CEILING)
     end
 
     # Picks a random theme song off disk and plays it through the host speaker.

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Last-resort backstop that reclaims a Puma thread (and the DB connection it holds)
+# if a conversation turn wedges. This is NOT a UX timeout — it is set well above any
+# legitimate turn so it only ever fires on a genuinely stuck thread.
+#
+# Scope: this wraps ONE web request = ONE conversation turn (a HASS POST to
+# /api/v1/conversation). It covers only the SYNCHRONOUS orchestrator pipeline —
+# Setup, PromptBuilder, the brain LLM call, ResponseSynthesizer, Finalizer. All the
+# async work (EnvironmentDirectorJob's HASS agent call, camera, summarizers, shows)
+# runs in SolidQueue and is NOT covered by this timer.
+#
+# Sizing: the dominant cost is the brain LLM call. LlmService can chain calls on a
+# bad-luck turn — primary (openrouter request_timeout 45s) + fallback-on-timeout
+# (up to 2 x 45s) + up to 2 heal attempts + a secondary retry — so a slow-but-VALID
+# turn can run well over a minute. 180s sits comfortably above that chain: it exists
+# only to reclaim a genuinely wedged thread, never to cut off a turn that would have
+# returned. The HASS voice client has given up long before this fires anyway, and on
+# a single-user 5-thread cube holding one wedged thread a little longer is harmless —
+# so err high. Bump it further if a legit turn ever gets killed.
+#
+# On timeout rack-timeout raises Rack::Timeout::RequestTimeoutError inside the request;
+# ConversationController's rescue turns it into the standard safe HASS error response.
+#
+# Inserted manually (gem is required as rack/timeout/base, so it does NOT auto-insert
+# its 15s default). Placed outermost so the timer covers the whole middleware stack.
+Rails.application.config.middleware.insert 0, Rack::Timeout,
+  service_timeout: 180,   # seconds of synchronous turn work before the thread is reclaimed
+  wait_timeout:    false  # single-user cube: don't 503 on queue wait

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       post "hass/grand_entrance", to: "home_assistant_webhook#grand_entrance"
       post "hass/glitch_short", to: "home_assistant_webhook#glitch_short"
       post "hass/glitch_long", to: "home_assistant_webhook#glitch_long"
+      post "hass/restart", to: "home_assistant_webhook#restart"
 
       namespace :home_assistant do
         get "health", to: "home_assistant#health"

--- a/data/homeassistant/automations/connectivity/backend_restart_watchdog.yaml
+++ b/data/homeassistant/automations/connectivity/backend_restart_watchdog.yaml
@@ -1,0 +1,33 @@
+# --- Backend wedged: last-resort restart -----------------------------------------
+# sensor.glitchcube_backend (templates/glitchcube_backend_health.yaml) reads "online"
+# only while Rails' once-a-minute heartbeat is < 3 min old, else UNAVAILABLE. That
+# heartbeat is written by a SolidQueue job, so it stops the moment the JOB workers
+# wedge — even while Puma is still answering HTTP. That specific state (jobs stuck /
+# backend degraded but the web thread alive) is both when a fresh boot helps AND when
+# the restart rest_command can still land, so it's the trigger here.
+#
+# 15-min debounce so a normal reboot / HASS-VM restart / brief blip never trips it.
+# Rails throttles honored restarts (10-min cooldown that survives the reboot), so even
+# if this re-fires there's no boot loop. If Rails is FULLY down the rest_command just
+# fails harmlessly — this can only ever HELP or no-op, never make things worse.
+#
+# NOTE: verify sensor.glitchcube_backend behaves as expected on the live box before
+# trusting this unattended — it was added without a running backend to test against.
+
+- id: backend_restart_watchdog
+  alias: "Backend: last-resort restart when wedged too long"
+  description: >-
+    If sensor.glitchcube_backend has been unavailable for 15 minutes (heartbeat dead
+    → jobs wedged / backend degraded), ask Rails to gracefully restart its whole
+    stack. Reachable only while Puma still serves HTTP; harmless no-op otherwise.
+  triggers:
+  - trigger: state
+    entity_id: sensor.glitchcube_backend
+    to: "unavailable"
+    for: "00:15:00"
+  conditions: []
+  actions:
+  - action: rest_command.glitchcube_restart_backend
+    data:
+      reason: "backend unavailable 15m (heartbeat dead)"
+  mode: single

--- a/data/homeassistant/packages/glitchcube_rails_triggers.yaml
+++ b/data/homeassistant/packages/glitchcube_rails_triggers.yaml
@@ -60,3 +60,16 @@ rest_command:
     method: POST
     content_type: "application/json"
     payload: "{}"
+
+  # LAST-RESORT self-heal: ask Rails to gracefully restart its whole backend stack
+  # (bin/glitchcube-ctl restart → launchd KeepAlive respawns Puma + jobs). Only lands
+  # while Puma still answers HTTP, so it heals the "jobs wedged / degraded but web is
+  # up" case (if Rails is fully down this simply fails, harmlessly). Rails throttles
+  # honored restarts (10 min cooldown, survives the reboot) so this can't boot-loop.
+  # Caller: the backend_restart_watchdog automation. Optional `reason` is logged.
+  glitchcube_restart_backend:
+    url: >-
+      http://{{ states('input_text.glitchcube_host') | trim }}{{ '' if ':' in states('input_text.glitchcube_host') else ':4567' }}/api/v1/hass/restart
+    method: POST
+    content_type: "application/json"
+    payload: '{"reason": "{{ reason | default("", true) }}"}'

--- a/spec/requests/api/v1/home_assistant_webhook_spec.rb
+++ b/spec/requests/api/v1/home_assistant_webhook_spec.rb
@@ -50,4 +50,32 @@ RSpec.describe "Home Assistant webhook API", type: :request do
       expect(response.parsed_body).to include("success" => true)
     end
   end
+
+  describe "POST /api/v1/hass/restart" do
+    before { Rails.cache.delete(Api::V1::HomeAssistantWebhookController::RESTART_CACHE_KEY) }
+
+    it "spawns a detached restart and reports restarted: true" do
+      # NEVER actually restart the backend from a test — assert on the spawn instead.
+      expect(Process).to receive(:spawn).with(/glitchcube-ctl.* restart/, pgroup: true).and_return(4242)
+      expect(Process).to receive(:detach).with(4242)
+
+      post '/api/v1/hass/restart', params: { reason: "test" }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["data"]).to include("restarted" => true, "reason" => "test")
+    end
+
+    it "honors the cooldown and does NOT spawn a second restart" do
+      allow(Process).to receive(:spawn).and_return(1)
+      allow(Process).to receive(:detach)
+
+      post '/api/v1/hass/restart', as: :json          # first one goes through
+      expect(response.parsed_body["data"]).to include("restarted" => true)
+
+      expect(Process).not_to receive(:spawn)          # second is throttled
+      post '/api/v1/hass/restart', as: :json
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["data"]).to include("restarted" => false, "reason" => "cooldown")
+    end
+  end
 end

--- a/spec/services/host_audio_spec.rb
+++ b/spec/services/host_audio_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe HostAudio do
       end
     end
 
-    it 'plays untruncated with no cap, fade, or timeout when max_seconds is omitted' do
+    it 'plays untruncated (no cap/fade) but still enforces a hard kill ceiling when max_seconds is omitted' do
       described_class.play("/tmp/song.mp3")
 
       expect(described_class).to have_received(:run) do |command, timeout:|
@@ -52,7 +52,9 @@ RSpec.describe HostAudio do
         expect(command).not_to include("-t ")
         expect(command).not_to include("afade")
         expect(command).to include(Shellwords.escape("/tmp/song.mp3"))
-        expect(timeout).to be_nil
+        # A wedged ffplay must never be joined on forever: uncapped play still
+        # gets the hard kill ceiling so it can't pin a SolidQueue worker.
+        expect(timeout).to eq(described_class::UNCAPPED_KILL_CEILING)
       end
     end
 


### PR DESCRIPTION
## What & why

A focused review (pal `codereview` + deepseek-v4-pro) of the conversation orchestrator ↔ Home Assistant path turned up several edge cases that can strand an **unattended** cube (deaf mic, wedged job thread, DB connection held across a multi-minute LLM call). This PR fixes the real hang vectors at the root, plus adds a last-resort self-heal. Pre-PR diff review by glm-5.2: *"exceptionally sound."*

## Commit 1 — hung-state hardening

- **`host_audio.rb`** — uncapped `play(max_seconds: nil)` did `wait_thr.join(nil)` → blocks **forever** on a wedged `ffplay`, pinning one of only 3 SolidQueue threads (reached via `ThemeSongJob`). Added `UNCAPPED_KILL_CEILING = 600` so `run` always gets a non-nil kill timeout. Playback is unchanged (`-autoexit` still exits at end-of-file).
- **`home_assistant_service.rb`** — added `open_timeout: 5` to `Net::HTTP.start` (was `read_timeout` only → a powered-off HASS box stalled the TCP connect ~60 s on every turn's sync-path persona read). `Net::OpenTimeout` is already rescued → `ConnectionError`, fast.
- **`conversation_orchestrator.rb`** — dropped the `ActiveRecord::Base.transaction` wrapping the 6-step pipeline. It held a DB connection open across the multi-minute brain LLM call for no atomicity benefit; partial turns self-heal.
- **`rack-timeout`** — added as a last-resort thread-reclaim backstop (180 s service timeout, manual insert at middleware position 0, `wait_timeout` off). Wraps one turn's synchronous work only; sized above the LLM primary+fallback+heal chain so it never cuts off a valid turn.

*Already handled, no change:* stuck `input_boolean.persona_switching` (deaf mic) self-recovers via the existing HASS `switching_watchdog.yaml` (2-min auto-off) + `switching_silence` off-edge un-mute — works even when the Rails worker is what died.

## Commit 2 — last-resort restart endpoint

- **`POST /api/v1/hass/restart`** — gracefully restarts the whole stack via `bin/glitchcube-ctl restart` (TERM → launchd `KeepAlive` respawns Puma + SolidQueue cleanly). Runs the script **detached, own process group, 3 s delay** so it survives Puma's own shutdown and the 200 flushes to HASS first. SolidCache-backed **10-min cooldown** (survives the reboot) prevents a boot loop.
- Reachable only while Puma answers HTTP, so it heals the "jobs wedged / degraded but web alive" case — exactly when `sensor.glitchcube_backend` goes `unavailable` (the heartbeat is a job). If Rails is fully down the rest_command just fails harmlessly.
- Request specs mock `Process.spawn`/`detach` — **tests never actually restart**.

## ⚠️ Deploy steps on merge

1. **`bundle install`** on the box (new gem: `rack-timeout`).
2. **scp these HASS files to `/config`** (they don't take effect until synced):
   - `data/homeassistant/packages/glitchcube_rails_triggers.yaml` — adds `rest_command.glitchcube_restart_backend`
   - `data/homeassistant/automations/connectivity/backend_restart_watchdog.yaml` — fires the restart after `sensor.glitchcube_backend` is `unavailable` for 15 min
3. **Verify `sensor.glitchcube_backend`** behaves as expected against the live backend before trusting the watchdog unattended — the automation was added without a running box to test against.

## Verification

- Full suite: **466 examples, 0 failures** (5 pending = dormant GPS). `rubocop` clean.
- Scenario spec drives the real orchestrator end-to-end (covers the transaction removal); the scenario harness and new request specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
