### PR TITLE
feat: add system_announcement action + HASS script

### DIFF
--- a/app/services/schemas/narrative_response_schema.rb
+++ b/app/services/schemas/narrative_response_schema.rb
@@ -41,7 +41,7 @@ class Schemas::NarrativeResponseSchema
              description: "OPTIONAL. Plain-English text (and optional color) for the scrolling sign (see YOUR TOOLS). Omit to leave the sign alone."
 
       string :other_actions, required: false,
-             description: "OPTIONAL. Plain-English catch-all — right now only a systems check or a persona switch (see YOUR TOOLS). Omit if none apply."
+             description: "OPTIONAL. Plain-English catch-all — right now a systems check, a persona switch, or a system announcement (see YOUR TOOLS). Omit if none apply."
 
       boolean :continue_conversation, required: true,
               description: "Whether to keep listening without a wake word. Err toward true; false only when the conversation has clearly ended (a goodbye) or the input is environmental noise, not someone talking to you."

--- a/data/homeassistant/README.md
+++ b/data/homeassistant/README.md
@@ -62,6 +62,9 @@ irrelevant to that.
 **audio/**
 - `jukebox.yaml` — `play_music_on_jukebox` (play a track/query, volume-aware), `search_jukebox` (search the library).
 - `sound_effects.yaml` — `play_sound_effect` (one of the bundled SFX via the jukebox).
+- `announcement.yaml` — `system_announcement` (chime + robotic non-persona TTS message over
+  the jukebox via `music_assistant.play_announcement`, volume-aware, default 75; ducks and
+  auto-resumes whatever was playing). Callable by any persona via the `other_actions` channel.
 
 **marquee/** — `marquee.yaml`
 - `awtrix_marquee_message` — flash a message (color/rainbow/duration) on the LED sign.
@@ -95,7 +98,10 @@ Input helpers stay in packages (they're finicky when split into include-dirs).
   - `input_number`: `quiet_mode_max_volume`. `input_button`: `trigger_alarm`.
 
   (Dev-mock helpers `dev_jukebox_song` / `dev_mood_music` / `dev_sound_effect` /
-  `announcement` and the `loudspeaker_announcement` dev script were removed.)
+  `announcement` and the `loudspeaker_announcement` dev script were removed. Real
+  announcement functionality was reintroduced as `scripts/audio/announcement.yaml`'s
+  `system_announcement`, above — no dev-mock helper needed since it uses the real
+  `music_assistant.play_announcement` service directly.)
 - `cube_screen.yaml` — M5Stack Core2 display helpers (`input_text.m5_screen_text` /
   `_emoji` / `_color`); entity_ids the ESPHome `cube-screen` firmware subscribes to.
 - `glitchcube_rails_triggers.yaml` — HASS→Rails `rest_command`s, all hitting the one

--- a/data/homeassistant/scripts/audio/announcement.yaml
+++ b/data/homeassistant/scripts/audio/announcement.yaml
@@ -1,0 +1,47 @@
+# --- System announcement -----------------------------------------------------------
+# An official, non-persona, robotic-voiced interruption over the jukebox speaker — for
+# genuine system notices or rare, sparing in-world trolling. Uses Music Assistant's own
+# announce feature (music_assistant.play_announcement), which plays a chime, ducks
+# whatever's currently playing, speaks the message via MA's configured default TTS
+# provider, and resumes playback afterward on its own — no extra fade/resume logic
+# needed here. For a "more robotic" voice, set Music Assistant's own default TTS
+# provider (in MA's own integration settings, not here) to something flat/synthetic
+# like eSpeak-NG, distinct from whatever the personas use for their Assist pipelines.
+
+system_announcement:
+  alias: System Announcement
+  description: >-
+    An official system announcement, spoken in a robotic, non-persona voice over the
+    jukebox speaker. Plays a chime first, then the message; if music is already playing
+    it ducks out and resumes automatically afterward. For genuine system notices or
+    rare, sparing in-world trolling (e.g. "the cube will shut down from boredom if this
+    conversation doesn't get more lively") — not for regular persona speech. Keep it to
+    a few sentences max, and use it sparingly.
+  fields:
+    message:
+      name: Message
+      description: The announcement text to speak. Keep it short — a few sentences max.
+      required: true
+      selector:
+        text:
+    volume:
+      name: Volume
+      description: Announcement volume, 0-100 percent. Defaults to 75.
+      required: false
+      default: 75
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider
+  sequence:
+  - action: music_assistant.play_announcement
+    target:
+      entity_id: media_player.jukebox_internal
+    data:
+      url: "{{ message }}"
+      use_pre_announcement: true
+      announce_volume: "{{ volume | default(75, true) | int }}"
+  mode: single

--- a/lib/prompts/general/tools.txt
+++ b/lib/prompts/general/tools.txt
@@ -62,4 +62,11 @@ several at once when several things should shift. Don't force them and don't rat
     who wants someone else. Name who takes over or leave it to chance ("hand off to Neon" /
     "let the cube pick whoever's next"). Say goodbye in your speech first — once it fires the
     next persona owns the cube and you get no last word.
+  - make a system announcement (action: system_announcement) — any persona can call this. A
+    chime, then a few sentences in a flat, robotic, NON-persona voice over the jukebox
+    speaker — it ducks whatever's playing and resumes it after. This is the cube itself
+    talking, not you, so don't narrate it as your own voice. For genuine official notices, or
+    rare, sparing in-world trolling ("the cube will shut down from boredom if this
+    conversation doesn't get more lively"). Use sparingly — a few sentences max, and it should
+    feel like an event, not a habit.
   Don't invent actions that aren't in this list.


### PR DESCRIPTION
## Summary
- Adds a `system_announcement` action, callable by any persona via the shared `other_actions` channel: a chime + a few sentences in a flat, robotic, non-persona voice over the jukebox speaker.
- New HASS script `data/homeassistant/scripts/audio/announcement.yaml` (`system_announcement`) using Music Assistant's native `play_announcement` service (chime, duck/resume, and TTS all handled by MA itself) — `message` (required) + `volume` (0-100, default 75).
- Updates `tools.txt`, the narrative response schema's one-liner, and the HASS README inventory/deploy notes.

## Deploy notes (manual, box-side)
- SCP `data/homeassistant/{configuration.yaml,automations,scripts,packages,templates}` to `root@glitch.local:/config/`, then `ha core check && ha core restart`.
- Expose the new `script.system_announcement` entity to Assist in the HA UI (not automatic).
- For a more "robotic" announcement voice, set Music Assistant's own default TTS provider (in MA's integration settings) to something synthetic-sounding, since MA's `play_announcement` uses its own configured default TTS, separate from the personas' Assist voices.

Closes #32.

🤖 Generated with [Claude Code](https://claude.ai/code)