### PR TITLE
feat: persona idle improv - idle musing via assist_satellite.announce

### DIFF
--- a/app/controllers/api/v1/home_assistant_webhook_controller.rb
+++ b/app/controllers/api/v1/home_assistant_webhook_controller.rb
@@ -48,4 +48,12 @@ class Api::V1::HomeAssistantWebhookController < Api::V1::BaseController
     ShowJob.perform_later("glitch_long")
     render_api_success(enqueued: true)
   end
+
+  # POST /api/v1/hass/idle_announce
+  # The current persona muses out loud while idle -> assist_satellite.announce
+  # (speaks without opening the mic). Fire-and-forget.
+  def idle_announce
+    IdleAnnounceJob.perform_later
+    render_api_success(enqueued: true)
+  end
 end

--- a/app/jobs/idle_announce_job.rb
+++ b/app/jobs/idle_announce_job.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Fire-and-forget idle musing: the current persona speaks unprompted, via
+# assist_satellite.announce (message-only — no mic opened), while the cube's
+# been sitting idle a while. Enqueued by
+# Api::V1::HomeAssistantWebhookController#idle_announce (HASS hits it via
+# rest_command, see data/homeassistant/automations/idle/glitch_ambient.yaml).
+#
+# This is the orchestrator's own steps minus setup/history/logging — a
+# lightweight, NON-LOGGED generation. It must NOT create a Conversation or
+# ConversationLog row, and must NOT land in the next turn's history window
+# (PromptService with conversation: nil builds an empty message history).
+# The persona may also change lights/sound/marquee as part of the musing —
+# that's dispatched through the normal two-lane ActionExecutor, same as any
+# other turn, just with conversation_id: nil (EnvironmentDirectorJob's
+# store_results no-ops on a missing conversation, so this is safe).
+class IdleAnnounceJob < ApplicationJob
+  queue_as :default
+
+  SATELLITE = Shows::Base::SATELLITE
+
+  IDLE_PROMPT = <<~PROMPT.squish
+    [SYSTEM] Nobody has been around for a while and the cube is just sitting here
+    idle. This is a private moment — think out loud to no one in particular, or try
+    to draw someone over. Say whatever's on your mind: an idle thought, a gripe, a
+    lure, a non-sequitur. Keep it short. You may also change your lights, put on
+    music, or update the marquee if you feel like it.
+  PROMPT
+
+  def perform
+    persona = CubePersona.current_persona
+    prompt_data = PromptService.build_prompt_for(persona: persona, conversation: nil, user_message: IDLE_PROMPT)
+
+    llm_result = ConversationOrchestrator::LlmIntention.call(
+      prompt_data: prompt_data,
+      user_message: IDLE_PROMPT,
+      model: model_chain
+    )
+    structured = llm_result.data[:llm_response]
+
+    # LlmIntention degrades to a fallback "I'm having trouble thinking" narrative
+    # rather than raising when the brain call fails — never announce that apology
+    # into an empty room.
+    return if structured["speech"] == ConversationOrchestrator::LlmIntention::FALLBACK_SPEECH
+
+    announce(structured["speech"]) if structured["speech"].present?
+
+    ConversationOrchestrator::ActionExecutor.call(
+      llm_response: structured,
+      session_id: "idle_announce_#{SecureRandom.hex(4)}",
+      conversation_id: nil,
+      user_message: IDLE_PROMPT,
+      persona: persona
+    )
+  end
+
+  private
+
+  def model_chain
+    [ Rails.configuration.ai_model, *ConversationOrchestrator::FALLBACK_MODELS ].uniq
+  end
+
+  def announce(speech)
+    HomeAssistantService.instance.call_service(
+      "assist_satellite", "announce", entity_id: SATELLITE, message: speech
+    )
+  end
+end

--- a/app/services/conversation_orchestrator/llm_intention.rb
+++ b/app/services/conversation_orchestrator/llm_intention.rb
@@ -1,5 +1,10 @@
 # app/services/conversation_orchestrator/llm_intention.rb
 class ConversationOrchestrator::LlmIntention
+  # The speech fallback_narrative hands back when the brain call fails. Exposed so
+  # callers that must NOT speak an apology into an empty room (e.g. IdleAnnounceJob)
+  # can detect the degraded case without duplicating the string.
+  FALLBACK_SPEECH = "I'm having trouble thinking right now — give me a moment.".freeze
+
   def self.call(prompt_data:, user_message:, model:)
     new(prompt_data: prompt_data, user_message: user_message, model: model).call
   end
@@ -110,7 +115,7 @@ class ConversationOrchestrator::LlmIntention
 
   def fallback_narrative
     {
-      "speech" => "I'm having trouble thinking right now — give me a moment.",
+      "speech" => FALLBACK_SPEECH,
       "continue_conversation" => false,
       "inner_monologue" => "Brain LLM call failed; spoke a graceful fallback so I'm not silent.",
       "actions" => []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       post "hass/grand_entrance", to: "home_assistant_webhook#grand_entrance"
       post "hass/glitch_short", to: "home_assistant_webhook#glitch_short"
       post "hass/glitch_long", to: "home_assistant_webhook#glitch_long"
+      post "hass/idle_announce", to: "home_assistant_webhook#idle_announce"
 
       namespace :home_assistant do
         get "health", to: "home_assistant#health"

--- a/data/homeassistant/automations/idle/glitch_ambient.yaml
+++ b/data/homeassistant/automations/idle/glitch_ambient.yaml
@@ -1,16 +1,19 @@
 - id: idle_glitch_ambient_show
-  alias: "Idle: ambient glitch show (roll every ~10 min)"
+  alias: "Idle: musing / ambient glitch show (roll every ~10 min)"
   description: >-
     Keeps the cube from sitting in dead silence. Once it's been idle 15 minutes, roll a
-    weighted die and — 50% of the time — kick off a SHORT glitch show, 25% a LONG one, and
-    25% do nothing. Then re-roll every ~10 minutes for as long as the cube stays idle. The
-    shows run Rails-side (Shows::GlitchShort / GlitchLong via their rest_commands) and play
-    at a low random volume so they just burble in the background, never blare like a cued
-    song. Idle = the assist satellite has been 'idle' a full 15 min (any conversation resets
-    that clock), and we skip while a persona switch / another show is running
-    (input_boolean.persona_switching). This is the only thing that fires the glitch
-    rest_commands. Cadence: a 1-min time pattern gates on "idle 15 min" + "last rolled >10
-    min ago", so the first roll lands at 15 min idle and every 10 min after.
+    weighted die — 50% of the time the current persona muses out loud (an unprompted
+    announcement via assist_satellite.announce, speaking without opening the mic), 30% a
+    SHORT glitch show, 20% a LONG one. There is no "nothing" outcome anymore — every roll
+    does something. Then re-roll every ~10 minutes for as long as the cube stays idle. The
+    musing and shows all run Rails-side (IdleAnnounceJob / Shows::GlitchShort / GlitchLong
+    via their rest_commands); the glitch shows play at a low random volume so they just
+    burble in the background, never blare like a cued song. Idle = the assist satellite has
+    been 'idle' a full 15 min (any conversation resets that clock), and we skip while a
+    persona switch / another show is running (input_boolean.persona_switching). This is the
+    only thing that fires the glitch/idle-announce rest_commands. Cadence: a 1-min time
+    pattern gates on "idle 15 min" + "last rolled >10 min ago", so the first roll lands at
+    15 min idle and every 10 min after.
   triggers:
   - trigger: time_pattern
     minutes: "/1"
@@ -21,19 +24,20 @@
     state: idle
     for: "00:15:00"
   # First roll at 15 min idle, then one every 10 min while still idle. `this` = this
-  # automation's own state, so last_triggered updates on every roll (even a "nothing" one).
+  # automation's own state, so last_triggered updates on every roll.
   - "{{ this.attributes.last_triggered is none or (now() - this.attributes.last_triggered) > timedelta(minutes=10) }}"
   actions:
   - variables:
-      # 1-100. 1-50 short (50%), 51-75 long (25%), 76-100 nothing (25%).
+      # 1-100. 1-50 idle musing (50%), 51-80 short glitch (30%), 81-100 long glitch (20%).
       roll: "{{ (range(1, 101) | list) | random }}"
   - choose:
     - conditions: "{{ roll <= 50 }}"
       sequence:
-      - action: rest_command.glitchcube_glitch_short
-    - conditions: "{{ roll <= 75 }}"
+      - action: rest_command.glitchcube_idle_announce
+    - conditions: "{{ roll <= 80 }}"
       sequence:
-      - action: rest_command.glitchcube_glitch_long
-    # roll 76-100: do nothing — the quiet outcome. The roll still counts, so the next
-    # one is ~10 min out.
+      - action: rest_command.glitchcube_glitch_short
+    # roll 81-100: long glitch show.
+    default:
+    - action: rest_command.glitchcube_glitch_long
   mode: single

--- a/data/homeassistant/packages/glitchcube_rails_triggers.yaml
+++ b/data/homeassistant/packages/glitchcube_rails_triggers.yaml
@@ -60,3 +60,13 @@ rest_command:
     method: POST
     content_type: "application/json"
     payload: "{}"
+
+  # The current persona muses out loud while idle — an unprompted announcement via
+  # assist_satellite.announce (speaks without opening the mic, so it's safe whether
+  # or not anyone's nearby). IdleAnnounceJob on the Rails side. Fire-and-forget.
+  glitchcube_idle_announce:
+    url: >-
+      http://{{ states('input_text.glitchcube_host') | trim }}{{ '' if ':' in states('input_text.glitchcube_host') else ':4567' }}/api/v1/hass/idle_announce
+    method: POST
+    content_type: "application/json"
+    payload: "{}"

--- a/spec/jobs/idle_announce_job_spec.rb
+++ b/spec/jobs/idle_announce_job_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IdleAnnounceJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:fake_ha) { FakeHomeAssistant.new(persona: 'jax') }
+
+  let(:narrative) do
+    {
+      'speech' => 'Nobody around, huh? Fine. I will just talk to this rock over here.',
+      'continue_conversation' => false,
+      'inner_monologue' => 'so bored',
+      'marquee' => 'HELLO???'
+    }
+  end
+
+  let(:brain_response) do
+    double(
+      'BrainResponse',
+      content: narrative.to_json,
+      structured_output: narrative,
+      model: 'test/brain',
+      usage: { 'total_tokens' => 10 }
+    )
+  end
+
+  before do
+    HomeAssistantService.instance = fake_ha
+    allow(LlmService).to receive(:call_with_structured_output).and_return(brain_response)
+    allow(EnvironmentDirectorJob).to receive(:perform_later)
+  end
+
+  after { HomeAssistantService.reset_instance! }
+
+  it 'announces the musing without opening the mic' do
+    described_class.new.perform
+
+    calls = fake_ha.service_calls_for('assist_satellite')
+    expect(calls.length).to eq(1)
+    expect(calls.first[:service]).to eq('announce')
+    expect(calls.first[:data][:entity_id]).to eq(Shows::Base::SATELLITE)
+    expect(calls.first[:data][:message]).to eq(narrative['speech'])
+  end
+
+  it 'never opens a conversation (no start_conversation call, no Conversation/ConversationLog rows)' do
+    expect {
+      described_class.new.perform
+    }.not_to change { Conversation.count }
+
+    expect(ConversationLog.count).to eq(0)
+    expect(fake_ha.service_calls_for('assist_satellite').map { |c| c[:service] }).not_to include('start_conversation')
+  end
+
+  it 'dispatches non-narrative action channels through the two-lane translator with conversation_id: nil' do
+    described_class.new.perform
+
+    expect(EnvironmentDirectorJob).to have_received(:perform_later).with(
+      hash_including(instruction: 'marquee: HELLO???', conversation_id: nil, convo_prefix: 'cube_env')
+    )
+  end
+
+  it 'skips the announce entirely when the brain call fails (fallback narrative)' do
+    allow(LlmService).to receive(:call_with_structured_output).and_raise('OpenRouter API timeout')
+
+    described_class.new.perform
+
+    expect(fake_ha.service_calls_for('assist_satellite')).to be_empty
+  end
+
+  it 'runs from the enqueued job pipeline' do
+    perform_enqueued_jobs do
+      described_class.perform_later
+    end
+
+    expect(fake_ha.service_calls_for('assist_satellite')).not_to be_empty
+  end
+end

--- a/spec/requests/api/v1/home_assistant_webhook_spec.rb
+++ b/spec/requests/api/v1/home_assistant_webhook_spec.rb
@@ -50,4 +50,15 @@ RSpec.describe "Home Assistant webhook API", type: :request do
       expect(response.parsed_body).to include("success" => true)
     end
   end
+
+  describe "POST /api/v1/hass/idle_announce" do
+    it "enqueues the idle musing and returns success" do
+      expect {
+        post '/api/v1/hass/idle_announce', as: :json
+      }.to have_enqueued_job(IdleAnnounceJob)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("success" => true)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds a third idle behavior alongside the existing glitch shows: the current persona muses out loud. The idle-ambient automation now rolls 50% musing / 30% short glitch / 20% long glitch (no more "do nothing" outcome).

- New `IdleAnnounceJob` reuses `PromptService` + `ConversationOrchestrator::LlmIntention` + `ConversationOrchestrator::ActionExecutor` directly (no new LLM glue), speaking via `assist_satellite.announce` (mic stays closed, works whether or not anyone's nearby).
- Lightweight / non-logged: no `Conversation` or `ConversationLog` row, nothing lands in the history window (`conversation: nil`).
- On a brain-call failure, `LlmIntention` degrades to a fallback apology narrative; the job detects that (new `LlmIntention::FALLBACK_SPEECH` constant) and skips the announce rather than speaking into an empty room.
- New rest_command + route + controller action mirroring the existing glitch webhooks.

## Test plan
- [x] `spec/jobs/idle_announce_job_spec.rb` - announce call, no Conversation/ConversationLog rows, action-channel dispatch with `conversation_id: nil`, fallback-skip, enqueued-pipeline smoke test
- [x] `spec/requests/api/v1/home_assistant_webhook_spec.rb` - new route enqueues the job
- [ ] CI run (could not execute rspec/rubocop locally in this sandbox - please confirm in CI)

Closes #34

Generated with [Claude Code](https://claude.ai/code)